### PR TITLE
Breaking change: timed no longer takes unit types and fix truncation of data

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
@@ -43,29 +43,17 @@ object Histogram {
   // Convenience ----------------------------------------------------
   // Since these methods are not ex
 
+
   /**
    * Persist a timed value into this [[Histogram]]
    *
    * @param h Histogram
    * @param fa The action to time
-   * @param unit The unit of time to observe the timing in. Default Histogram buckets
-   *  are optimized for `SECONDS`.
    */
-  def timed[E, F[_]: Bracket[?[_], E]: Clock, A](h: Histogram[F], fa: F[A], unit: TimeUnit): F[A] =
-    Bracket[F, E].bracket(Clock[F].monotonic(unit))
-    {_: Long => fa}
-    {start: Long => Clock[F].monotonic(unit).flatMap(now => h.observe((now - start).toDouble))}
-
-  /**
-   * Persist a timed value into this [[Histogram]] in unit Seconds. This is exposed.
-   * since default buckets are in seconds it makes sense the general case will be to
-   * match the default buckets.
-   *
-   * @param h Histogram
-   * @param fa The action to time
-   */
-  def timedSeconds[E, F[_]: Bracket[?[_], E]: Clock, A](h: Histogram[F], fa: F[A]): F[A] =
-    timed(h, fa, SECONDS)
+  def timed[E, F[_]: Bracket[?[_], E]: Clock, A](h: Histogram[F], fa: F[A]): F[A] = 
+    Bracket[F, E].bracket(Clock[F].monotonic(NANOSECONDS)) 
+    {_: Long => fa} 
+    {start: Long => Clock[F].monotonic(NANOSECONDS).flatMap(now => h.observe((now - start) / 1E9))}
 
   // Constructors ---------------------------------------------------
   /**

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
@@ -45,8 +45,8 @@ object Histogram {
 
 
   /**
-   * Persist a timed value into this [[Histogram]]
-   *
+   * Persist a timed value into this [[Histogram]] in seconds. 
+   * Histogram buckets are measured in doubles of seconds.
    * @param h Histogram
    * @param fa The action to time
    */

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/syntax/histogram.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/syntax/histogram.scala
@@ -2,18 +2,14 @@ package io.chrisdavenport.epimetheus
 package syntax
 
 import cats.effect._
-import scala.concurrent.duration._
 
 trait histogram {
 
   implicit class HistogramTimedOp[E, F[_]: Bracket[?[_],E]: Clock](
     private val h: Histogram[F]
   ){
-    def timed[A](fa: F[A], unit: TimeUnit): F[A] = 
-      Histogram.timed(h, fa, unit)
-
-    def timedSeconds[A](fa: F[A]): F[A] =
-      Histogram.timedSeconds(h, fa)
+    def timed[A](fa: F[A]): F[A] = 
+      Histogram.timed(h, fa)
   }
 
 }

--- a/docs/src/main/tut/docs/07-Histogram.md
+++ b/docs/src/main/tut/docs/07-Histogram.md
@@ -48,7 +48,7 @@ val noLabelsHistogramExample = {
     cr <- CollectorRegistry.build[IO]
     h <- Histogram.noLabels(cr, Name("example_histogram"), "Example Histogram")
     _ <- h.observe(0.2)
-    _ <- h.timed(T.sleep(1.second), SECONDS)
+    _ <- h.timed(T.sleep(1.second))
     currentMetrics <- cr.write004
     _ <- IO(println(currentMetrics))
   } yield ()
@@ -71,7 +71,7 @@ val labelledHistogramExample = {
       {s: String => Sized(s)}
     )
     _ <- h.label("bar").observe(0.2)
-    _ <- h.label("baz").timed(T.sleep(1.second), SECONDS)
+    _ <- h.label("baz").timed(T.sleep(1.second))
     currentMetrics <- cr.write004
     _ <- IO(println(currentMetrics))
   } yield ()

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -72,7 +72,7 @@ val noLabelsHistogramExample = {
     cr <- CollectorRegistry.build[IO]
     h <- Histogram.noLabels(cr, Name("example_histogram"), "Example Histogram")
     _ <- h.observe(0.2)
-    _ <- h.timed(T.sleep(1.second), SECONDS)
+    _ <- h.timed(T.sleep(1.second))
     currentMetrics <- cr.write004
   } yield currentMetrics
 }


### PR DESCRIPTION
Fixes the issue with: https://github.com/ChristopherDavenport/epimetheus/issues/152

If you'd like me to keep the old methods around and make this new one and name it something instead of making a binary incompatible change let me know what you'd like to see happen and we can do it that way instead.  