### PR TITLE
Rework time truncation for Summaries

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
@@ -43,29 +43,17 @@ object Histogram {
   // Convenience ----------------------------------------------------
   // Since these methods are not ex
 
+
   /**
    * Persist a timed value into this [[Histogram]]
    *
    * @param h Histogram
    * @param fa The action to time
-   * @param unit The unit of time to observe the timing in. Default Histogram buckets
-   *  are optimized for `SECONDS`.
    */
-  def timed[E, F[_]: Bracket[?[_], E]: Clock, A](h: Histogram[F], fa: F[A], unit: TimeUnit): F[A] =
-    Bracket[F, E].bracket(Clock[F].monotonic(unit))
-    {_: Long => fa}
-    {start: Long => Clock[F].monotonic(unit).flatMap(now => h.observe((now - start).toDouble))}
-
-  /**
-   * Persist a timed value into this [[Histogram]] in unit Seconds. This is exposed.
-   * since default buckets are in seconds it makes sense the general case will be to
-   * match the default buckets.
-   *
-   * @param h Histogram
-   * @param fa The action to time
-   */
-  def timedSeconds[E, F[_]: Bracket[?[_], E]: Clock, A](h: Histogram[F], fa: F[A]): F[A] =
-    timed(h, fa, SECONDS)
+  def timed[E, F[_]: Bracket[?[_], E]: Clock, A](h: Histogram[F], fa: F[A]): F[A] = 
+    Bracket[F, E].bracket(Clock[F].monotonic(NANOSECONDS)) 
+    {_: Long => fa} 
+    {start: Long => Clock[F].monotonic(NANOSECONDS).flatMap(now => h.observe((now - start) / 1E9))}
 
   // Constructors ---------------------------------------------------
   /**

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
@@ -45,8 +45,8 @@ object Histogram {
 
 
   /**
-   * Persist a timed value into this [[Histogram]]
-   *
+   * Persist a timed value into this [[Histogram]] in seconds. 
+   * Histogram buckets are measured in doubles of seconds.
    * @param h Histogram
    * @param fa The action to time
    */

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/Summary.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/Summary.scala
@@ -49,23 +49,11 @@ object Summary {
    *
    * @param s The summary to persist into.
    * @param fa The action to time
-   * @param unit The unit of time to observe the timing in.
    */
-  def timed[E, F[_]: Bracket[?[_], E]: Clock, A](s: Summary[F], fa: F[A], unit: TimeUnit): F[A] =
-    Bracket[F, E].bracket(Clock[F].monotonic(unit))
+  def timed[E, F[_]: Bracket[?[_], E]: Clock, A](s: Summary[F], fa: F[A]): F[A] =
+    Bracket[F, E].bracket(Clock[F].monotonic(NANOSECONDS))
     {_: Long => fa}
-    {start: Long => Clock[F].monotonic(unit).flatMap(now => s.observe((now - start).toDouble))}
-
-  /**
-   * Persist a timed value into this [[Summary]] in unit Seconds. Since the default
-   * buckets for histogram are in seconds and Summary are in some ways counterparts
-   * to histograms, this exposes convenience function.
-   *
-   * @param s The summary to persist to
-   * @param fa The action to time
-   */
-  def timedSeconds[E, F[_]: Bracket[?[_], E]: Clock, A](s: Summary[F], fa: F[A]): F[A] =
-    timed(s, fa, SECONDS)
+    {start: Long => Clock[F].monotonic(NANOSECONDS).flatMap(now => s.observe((now - start) / 1E9))}
 
   // Constructors ---------------------------------------------------
   val defaultMaxAgeSeconds = 600L

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/syntax/histogram.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/syntax/histogram.scala
@@ -2,18 +2,14 @@ package io.chrisdavenport.epimetheus
 package syntax
 
 import cats.effect._
-import scala.concurrent.duration._
 
 trait histogram {
 
   implicit class HistogramTimedOp[E, F[_]: Bracket[?[_],E]: Clock](
     private val h: Histogram[F]
   ){
-    def timed[A](fa: F[A], unit: TimeUnit): F[A] = 
-      Histogram.timed(h, fa, unit)
-
-    def timedSeconds[A](fa: F[A]): F[A] =
-      Histogram.timedSeconds(h, fa)
+    def timed[A](fa: F[A]): F[A] = 
+      Histogram.timed(h, fa)
   }
 
 }

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/syntax/summary.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/syntax/summary.scala
@@ -2,18 +2,14 @@ package io.chrisdavenport.epimetheus
 package syntax
 
 import cats.effect._
-import scala.concurrent.duration._
 
 trait summary {
 
   implicit class SummaryTimedOp[E, F[_]: Bracket[?[_],E]: Clock](
     private val s: Summary[F]
   ){
-    def timed[A](fa: F[A], unit: TimeUnit): F[A] = 
-      Summary.timed(s, fa, unit)
-
-    def timedSeconds[A](fa: F[A]): F[A] = 
-      Summary.timedSeconds(s, fa)
+    def timed[A](fa: F[A]): F[A] = 
+      Summary.timed(s, fa)
   }
 
 }

--- a/docs/src/main/tut/docs/07-Histogram.md
+++ b/docs/src/main/tut/docs/07-Histogram.md
@@ -48,7 +48,7 @@ val noLabelsHistogramExample = {
     cr <- CollectorRegistry.build[IO]
     h <- Histogram.noLabels(cr, Name("example_histogram"), "Example Histogram")
     _ <- h.observe(0.2)
-    _ <- h.timed(T.sleep(1.second), SECONDS)
+    _ <- h.timed(T.sleep(1.second))
     currentMetrics <- cr.write004
     _ <- IO(println(currentMetrics))
   } yield ()
@@ -71,7 +71,7 @@ val labelledHistogramExample = {
       {s: String => Sized(s)}
     )
     _ <- h.label("bar").observe(0.2)
-    _ <- h.label("baz").timed(T.sleep(1.second), SECONDS)
+    _ <- h.label("baz").timed(T.sleep(1.second))
     currentMetrics <- cr.write004
     _ <- IO(println(currentMetrics))
   } yield ()

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -72,7 +72,7 @@ val noLabelsHistogramExample = {
     cr <- CollectorRegistry.build[IO]
     h <- Histogram.noLabels(cr, Name("example_histogram"), "Example Histogram")
     _ <- h.observe(0.2)
-    _ <- h.timed(T.sleep(1.second), SECONDS)
+    _ <- h.timed(T.sleep(1.second))
     currentMetrics <- cr.write004
   } yield currentMetrics
 }


### PR DESCRIPTION
Piggybacking off of https://github.com/ChristopherDavenport/epimetheus/pull/154 this does the same work for Summaries and is branched off of #154 