### PR TITLE
feat: expose `Collector` for cleaning up transient metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ project/metals.sbt
 .vscode
 
 .bsp/
+
+.DS_Store
+
+GPATH
+GRTAGS
+GTAGS


### PR DESCRIPTION
If your metrics last the whole lifetime of your service, you can just bury the collector.
However there are times in which they do not last that long---for example, if
there is some a startup sequence your service goes through that you need
visibility into---in which case you need a `Collector` exposed to unregister.