### PR TITLE
Remove Private Sized

### DIFF
--- a/core/src/main/scala-2/io/chrisdavenport/epimetheus/ShapelessPolyfill.scala
+++ b/core/src/main/scala-2/io/chrisdavenport/epimetheus/ShapelessPolyfill.scala
@@ -6,7 +6,6 @@ trait ShapelessPolyfill {
 
   type Sized[+Repr, L <: Nat] = shapeless.Sized[Repr, L]
 
-  // For tests, user code on Scala 2 should just import shapeless.Sized
-  private[epimetheus] val Sized = shapeless.Sized
+  val Sized = shapeless.Sized
 
 }

--- a/docs/docs/05-Counter.md
+++ b/docs/docs/05-Counter.md
@@ -21,7 +21,6 @@ Imports
 ```scala mdoc:silent
 import io.chrisdavenport.epimetheus._
 import cats.effect._
-import shapeless._
 
 import cats.effect.unsafe.implicits.global
 ```

--- a/docs/docs/06-Gauge.md
+++ b/docs/docs/06-Gauge.md
@@ -20,7 +20,6 @@ Imports
 ```scala mdoc:silent
 import io.chrisdavenport.epimetheus._
 import cats.effect._
-import shapeless._
 
 import cats.effect.unsafe.implicits.global
 ```

--- a/docs/docs/07-Histogram.md
+++ b/docs/docs/07-Histogram.md
@@ -31,7 +31,6 @@ Imports
 import io.chrisdavenport.epimetheus._
 import io.chrisdavenport.epimetheus.implicits._
 import cats.effect._
-import shapeless._
 
 import scala.concurrent.duration._
 

--- a/docs/docs/08-Summary.md
+++ b/docs/docs/08-Summary.md
@@ -29,7 +29,6 @@ Imports
 ```scala mdoc:silent
 import io.chrisdavenport.epimetheus._
 import cats.effect._
-import shapeless._
 
 import cats.effect.unsafe.implicits.global
 ```


### PR DESCRIPTION
@ybasket Can explain why this comment was in place. I use this private by accident over here to great effect. Think it should probably be public, but want to know if there was a reason I missed.

https://github.com/davenverse/epimetheus-http4s/blob/main/core/src/main/scala/io/chrisdavenport/epimetheus/http4s/EpimetheusOps.scala#L183

Without it, folks can't cross their metrics across scala versions as they need two different constructors depending on the version.