### PR TITLE
Allow converting Java collectors into Epimetheus collectors

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/epimetheus/Counter.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/Counter.scala
@@ -163,5 +163,7 @@ object Counter {
       case m: UnlabelledCounterImpl[_, _] => m.underlying
     }
     def asJava[F[_]](c: Counter[F]): F[JCounter] = c.asJava
+    def fromJava[F[_]: Sync](c: JCounter.Child): Counter[F] = new LabelledCounter(c)
+    def fromJavaUnlabelled[F[_]: Sync](c: JCounter): Counter[F] = new NoLabelsCounter(c)
   }
 }

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/Gauge.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/Gauge.scala
@@ -215,5 +215,7 @@ object Gauge {
       case x: MapKUnlabelledGauge[f, _, a] => asJavaUnlabelled(x.base)
     }
     def asJava[F[_]](c: Gauge[F]): F[JGauge] = c.asJava
+    def fromJava[F[_]: Sync](g: JGauge.Child): Gauge[F] = new LabelledGauge(g)
+    def fromJavaUnlabelled[F[_]: Sync](g: JGauge): Gauge[F] = new NoLabelsGauge(g)
   }
 }

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/Histogram.scala
@@ -301,6 +301,8 @@ object Histogram {
       case h: MapKUnlabelledHistogram[f, _, a] => asJavaUnlabelled(h.base)
     }
     def asJava[F[_]](c: Histogram[F]): F[JHistogram] = c.asJava
+    def fromJava[F[_]: Sync](h: JHistogram.Child): Histogram[F] = new LabelledHistogram(h)
+    def fromJavaUnlabelled[F[_]: Sync](h: JHistogram): Histogram[F] = new NoLabelsHistogram(h)
   }
 
 }

--- a/core/src/main/scala/io/chrisdavenport/epimetheus/SummaryCommons.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/SummaryCommons.scala
@@ -248,5 +248,7 @@ trait SummaryCommons {
       case a: MapKUnlabelledSummary[f, _, a] => asJavaUnlabelled(a.base)
     }
     def asJava[F[_]](c: Summary[F]): F[JSummary] = c.asJava
+    def fromJava[F[_]: Sync](s: JSummary.Child): Summary[F] = new LabelledSummary(s)
+    def fromJavaUnlabelled[F[_]: Sync](s: JSummary): Summary[F] = new NoLabelsSummary(s)
   }
 }


### PR DESCRIPTION
This change will allow lifting existing Java collectors into their Epimetheus equivalents.