### PR TITLE
fix: replace placeholder titles with the real ones

### DIFF
--- a/docs/docs/01-Introduction.md
+++ b/docs/docs/01-Introduction.md
@@ -1,9 +1,3 @@
----
-layout: docs
-number: 1
-title: Introduction
----
-
 # Introduction
 
 This is a short book about **epimetheus** a pure functional Prometheus integration for Scala.

--- a/docs/docs/01-Introduction.md
+++ b/docs/docs/01-Introduction.md
@@ -4,7 +4,7 @@ number: 1
 title: Introduction
 ---
 
-# {{page.title}}
+# Introduction
 
 This is a short book about **epimetheus** a pure functional Prometheus integration for Scala.
 

--- a/docs/docs/02-BigPicture.md
+++ b/docs/docs/02-BigPicture.md
@@ -1,9 +1,3 @@
----
-layout: docs
-number: 2
-title: Big Picture
----
-
 # Big Picture
 
 **Epimetheus** is a functional API placed over the underyling [Prometheus Java Client](https://github.com/prometheus/client_java).

--- a/docs/docs/02-BigPicture.md
+++ b/docs/docs/02-BigPicture.md
@@ -4,7 +4,7 @@ number: 2
 title: Big Picture
 ---
 
-# {{page.title}}
+# Big Picture
 
 **Epimetheus** is a functional API placed over the underyling [Prometheus Java Client](https://github.com/prometheus/client_java).
 

--- a/docs/docs/03-DataModel.md
+++ b/docs/docs/03-DataModel.md
@@ -1,9 +1,3 @@
----
-layout: docs
-number: 3
-title: Data Model
----
-
 # Data Model
 
 Prometheus fundamentally stores all data as time series: streams of timestamped values belonging to the same metric and the same set of labeled dimensions. Besides stored time series, Prometheus may generate temporary derived time series as the result of queries.

--- a/docs/docs/04-CollectorRegistry.md
+++ b/docs/docs/04-CollectorRegistry.md
@@ -4,7 +4,7 @@ number: 4
 title: CollectorRegistry
 ---
 
-# {{page.title}}
+# Collector Registry
 
 A `CollectorRegistry` represents the concurrently shared state which holds the information
 of the metrics in question.

--- a/docs/docs/04-CollectorRegistry.md
+++ b/docs/docs/04-CollectorRegistry.md
@@ -1,9 +1,3 @@
----
-layout: docs
-number: 4
-title: CollectorRegistry
----
-
 # Collector Registry
 
 A `CollectorRegistry` represents the concurrently shared state which holds the information

--- a/docs/docs/05-Counter.md
+++ b/docs/docs/05-Counter.md
@@ -4,7 +4,7 @@ number: 5
 title: Counter
 ---
 
-# {{page.title}}
+# Counter
 
 Counter metric, to track counts, running totals, or events.
 

--- a/docs/docs/05-Counter.md
+++ b/docs/docs/05-Counter.md
@@ -1,9 +1,3 @@
----
-layout: docs
-number: 5
-title: Counter
----
-
 # Counter
 
 Counter metric, to track counts, running totals, or events.

--- a/docs/docs/06-Gauge.md
+++ b/docs/docs/06-Gauge.md
@@ -1,9 +1,3 @@
----
-layout: docs
-number: 6
-title: Gauge
----
-
 # Gauge
 
 Gauge metric, to report instantaneous values.

--- a/docs/docs/06-Gauge.md
+++ b/docs/docs/06-Gauge.md
@@ -4,7 +4,7 @@ number: 6
 title: Gauge
 ---
 
-# {{page.title}}
+# Gauge
 
 Gauge metric, to report instantaneous values.
 

--- a/docs/docs/07-Histogram.md
+++ b/docs/docs/07-Histogram.md
@@ -4,7 +4,7 @@ number: 7
 title: Histogram
 ---
 
-# {{page.title}}
+# Histogram
 
 Histogram metric, to track distributions of events.
 

--- a/docs/docs/07-Histogram.md
+++ b/docs/docs/07-Histogram.md
@@ -1,9 +1,3 @@
----
-layout: docs
-number: 7
-title: Histogram
----
-
 # Histogram
 
 Histogram metric, to track distributions of events.

--- a/docs/docs/08-Summary.md
+++ b/docs/docs/08-Summary.md
@@ -4,7 +4,7 @@ number: 8
 title: Summary
 ---
 
-# {{page.title}}
+# Summary
 
 Summary metric, to track the size of events.
 

--- a/docs/docs/08-Summary.md
+++ b/docs/docs/08-Summary.md
@@ -1,9 +1,3 @@
----
-layout: docs
-number: 8
-title: Summary
----
-
 # Summary
 
 Summary metric, to track the size of events.


### PR DESCRIPTION
I have not tested the microsite locally, but I assume that these changes would fix it.

![image](https://user-images.githubusercontent.com/104377763/186493543-132d75b3-54da-4eea-ae0f-400626db073d.png)
